### PR TITLE
Mining hash / operation queues proposal

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/vapor/fluent.git",
         "state": {
           "branch": null,
-          "revision": "6c730921636f660cdaafe1b83b7e6ab86bc3c55f",
-          "version": "2.5.0"
+          "revision": "84b0d96a61b66168f2a61ec788581e0a2ab6f9c3",
+          "version": "2.5.1"
         }
       },
       {
@@ -150,8 +150,8 @@
         "repositoryURL": "https://github.com/vapor/sockets.git",
         "state": {
           "branch": null,
-          "revision": "70d14c0e223257176f5ef69a595f7cad5de7a88b",
-          "version": "2.2.1"
+          "revision": "a77816695630a44d5d1393fc71eac37ac3d082ca",
+          "version": "2.2.2"
         }
       },
       {

--- a/README.md
+++ b/README.md
@@ -54,3 +54,16 @@ Block header:
 - Proper node syncing
 - Signatures
 - Transactions
+
+## Getting started
+
+    brew install vapor/tap/vapor
+    
+    In project root directory:
+    vapor update
+    vapor build 
+    vapor run
+
+##  Difficulty Factor
+   To mine a block, you can drop down the difficulty by removing zeroes in Miner.swift:
+   while (!candidate.blockHash.binaryString.hasPrefix("000000000000000000000000000000")) 

--- a/Sources/App/Droplet+Setup.swift
+++ b/Sources/App/Droplet+Setup.swift
@@ -3,25 +3,24 @@ import Foundation
 
 //Global client state
 let state = State()
-let miningEnabled = true
+
+class HashingOperation: Operation {
+    override var isAsynchronous: Bool {
+        return true
+    }
+    
+    
+ }
 
 extension Droplet {
+    
     public func setup() throws {
         try setupRoutes()
         
-        //For now init state by reading value from there.
-        print("BlockChain count: \(state.blockChain.count)")
-        
-        if miningEnabled {
-            let miner = Miner(coinbase: "asdf", diff: 5000, threadCount: 4)
-            while true {
-                sleep(1)
-//                usleep(20) // without this - getPreviousBlock().blockHash can disconnect from state
-                let newBlock = Block(prevHash: state.getPreviousBlock().blockHash, depth: state.blockDepth, txns: [Transaction()], timestamp: Date().timeIntervalSince1970, difficulty: 5000, nonce: 0, hash: Data())
-                miner.mineBlock(block: newBlock) { foundBlock in
-                    miner.blockFound(block: foundBlock) //Update state, print output
-                }
-            }
-        }
+    
+        Miner.beginMiningOnSingleThread()
+
     }
+
+    
 }

--- a/Sources/App/Droplet+Setup.swift
+++ b/Sources/App/Droplet+Setup.swift
@@ -4,13 +4,17 @@ import Foundation
 //Global client state
 let state = State()
 
-class HashingOperation: Operation {
+class ConcurrentOperation: Operation {
     override var isAsynchronous: Bool {
         return true
     }
-    
-    
  }
+
+class MiningOperation: Operation {
+    override var isAsynchronous: Bool {
+        return false
+    }
+}
 
 extension Droplet {
     

--- a/Sources/App/Models/Block.swift
+++ b/Sources/App/Models/Block.swift
@@ -18,6 +18,7 @@ final class Block: NSObject, NSCoding {
     }
     var timestamp: Double //Unix Tstamp
     var target: Float
+    var depthTarget:Int
     var nonce: UInt64 //64 bit nonce
     
     var depth: Int
@@ -30,6 +31,7 @@ final class Block: NSObject, NSCoding {
     }
     
     override init() {
+        self.depthTarget = -1
         self.prevHash = Data()
         self.timestamp = Date().timeIntervalSince1970
         self.target = 1
@@ -42,6 +44,7 @@ final class Block: NSObject, NSCoding {
     }
     
     init(prevHash: Data, depth: Int, txns: [Transaction], timestamp: Double, difficulty: Float, nonce: UInt64, hash: Data) {
+        self.depthTarget = -1
         self.prevHash = prevHash
         self.depth = depth
         self.txns = txns
@@ -115,6 +118,21 @@ final class Block: NSObject, NSCoding {
         
         /*aCoder.encode(depth, forKey: "depth")
          aCoder.encode(txns, forKey: "txns")*/
+    }
+    
+    func debug(){
+        let date = Date(timeIntervalSince1970: self.timestamp)
+        let formatter = DateFormatter()
+        formatter.dateFormat = "dd-MM-YYYY hh:mm:ss"
+        let dateString = formatter.string(from: date)
+
+        print("prevHash  : \(self.prevHash.hexString)")
+        print("hash      : \(self.blockHash.hexString)")
+        print("nonce     : \(self.nonce)")
+
+        print("merkleRoot: \(self.merkleRoot.hexString)")
+        print("timestamp : \(self.timestamp) (\(dateString))")
+        print("targetDiff: \(self.target)\n")
     }
 }
 

--- a/Sources/App/Models/ClientProtocol.swift
+++ b/Sources/App/Models/ClientProtocol.swift
@@ -190,7 +190,7 @@ class P2PProtocol {
 			state.blockChain.append(block)
 			
 			state.blocksSinceDifficultyUpdate += 1
-			state.blockDepth += 1
+			
 			if state.blocksSinceDifficultyUpdate >= 60 {
 				state.updateDifficulty()
 			}

--- a/Sources/App/Models/Miner.swift
+++ b/Sources/App/Models/Miner.swift
@@ -154,7 +154,7 @@ class Miner {
                 if !state.blockFound{
                     state.blockFound = true
                     
-                    block.debug()
+//                    block.debug()
                     print("depth     : \(state.blockChain.count)") // TODO - logInfo - this should increase and not skip!!!
                     state.blocksSinceDifficultyUpdate += 1
                     state.blockChain.append(block)

--- a/Sources/App/Models/Miner.swift
+++ b/Sources/App/Models/Miner.swift
@@ -65,7 +65,7 @@ class Miner {
         state.blockFound = false
         state.blockFoundQueue.cancelAllOperations()
         
-        let miner = Miner(coinbase: "coinbaseAddressNotImplementedYet", diff: 20, threadCount: 400)
+        let miner = Miner(coinbase: "coinbaseAddressNotImplementedYet", diff: 20, threadCount: 4)
         let block = Block(prevHash: state.getPreviousBlock().blockHash, depth: state.blockChain.count, txns: [Transaction()], timestamp: Date().timeIntervalSince1970, difficulty: 5000, nonce: 0, hash: Data())
         
         block.nonce = 0

--- a/Sources/App/Models/Miner.swift
+++ b/Sources/App/Models/Miner.swift
@@ -65,7 +65,7 @@ class Miner {
         state.blockFound = false
         state.blockFoundQueue.cancelAllOperations()
         
-        let miner = Miner(coinbase: "coinbaseAddressNotImplementedYet", diff: 20, threadCount: 4)
+        let miner = Miner(coinbase: "coinbaseAddressNotImplementedYet", diff: 20, threadCount: 400)
         let block = Block(prevHash: state.getPreviousBlock().blockHash, depth: state.blockChain.count, txns: [Transaction()], timestamp: Date().timeIntervalSince1970, difficulty: 5000, nonce: 0, hash: Data())
         
         block.nonce = 0
@@ -182,7 +182,10 @@ class Miner {
            
             // recover from cancelled operations.
             if (state.miningQueue.operationCount == 0){
-                print("attempting to recover")
+                if Miner.debug{
+                    print("attempting to recover")
+                }
+                
                 state.miningQueue.cancelAllOperations()
                  usleep(Miner.bandAidDelay)
                 ThreadSupervisor.createAndRunThread(target: Miner.self, selector: #selector(Miner.queueUpMiningOperation), object: nil)

--- a/Sources/App/Models/Miner.swift
+++ b/Sources/App/Models/Miner.swift
@@ -61,7 +61,7 @@ class Miner {
         state.blockFound = false
         state.blockFoundQueue.cancelAllOperations()
         
-        let miner = Miner(coinbase: "coinbaseAddressNotImplementedYet", diff: 20, threadCount: 40)
+        let miner = Miner(coinbase: "coinbaseAddressNotImplementedYet", diff: 20, threadCount: 4)
         let block = Block(prevHash: state.getPreviousBlock().blockHash, depth: state.blockChain.count, txns: [Transaction()], timestamp: Date().timeIntervalSince1970, difficulty: 5000, nonce: 0, hash: Data())
         
         block.nonce = 0

--- a/Sources/App/Models/Miner.swift
+++ b/Sources/App/Models/Miner.swift
@@ -163,11 +163,10 @@ class Miner {
         state.miningQueue.cancelAllOperations()
 //        let sleepCount:useconds_t = difficulty < 2000 ? 200000:difficulty*2000
         usleep(100000000 * difficultyHeight) // we need to give the some cycles to correctly cancel existing operations across threads - otherwise this thread can get caught up with cancelling - and basically miner runs out of things todo
-//        ThreadSupervisor.createAndRunThread(target: Miner.self, selector: #selector(mine), object: nil)
+        ThreadSupervisor.createAndRunThread(target: Miner.self, selector: #selector(mine), object: nil)
 //        print("numberOfThreads:",ThreadSupervisor.numberOfThreads)
 //        print("state.blockFound:",state.blockFound)
-        
-        Miner.mine()
+//        Miner.mine()
 
     }
 }

--- a/Sources/App/Models/Miner.swift
+++ b/Sources/App/Models/Miner.swift
@@ -9,9 +9,12 @@ import Foundation
 
 
 
+// TODO - unit tests
+// thread count 4 -> 4000
+// hashDifficulty low + high
 class Miner {
     
-    //static let shared = Miner()
+    static var debug = true
     
     //Address
     var coinbase: String
@@ -22,32 +25,40 @@ class Miner {
     var timeStamp: Double = Date().timeIntervalSince1970
     
     //Hardware params
-    var threadCount: Int = 1
+    static var threadCount: Int = 1
+    
+    // Reduce to make mining faster
+    static var hashDifficulty:String  = "0000000"
     
     init(coinbase: String, diff: Int64, threadCount: Int) {
-        print("Starting VaporCoin miner with \(threadCount) threads")
+        if Miner.debug{
+               print("Starting VaporCoin miner with \(threadCount) threads")
+        }
         self.coinbase = coinbase
         self.difficulty = diff
-        self.threadCount = threadCount
+        Miner.threadCount = threadCount
     }
     
     
     // This single entry point creates a VaporCoin Supervisor Thread - which is intended to  have ever have one thread.
-    // N.B. the count in SupervisorThread includes main thread so count is 2 out (but main thread isn't accessible from within vapor droplet).
+    // N.B. the count in SupervisorThread includes main thread so count is 2  (but main thread isn't accessible from within vapor droplet).
      @objc static func beginMiningOnSingleThread(){
         ThreadSupervisor.createAndRunThread(target: Miner.self, selector: #selector(Miner.mine), object: nil)
     }
     
-    // From here we are creating a ConcurrentOperation and queuing up to a single OperationQueue with concurrency threading /multi-threads .
+    // From here we are creating a ConcurrentOperation and queuing up to a single OperationQueue with concurrency threading /multi-threading .
     // We are using  OperationQueues instead DispatchQueues to organize / centralize cancelling of operations across threads.
     // TODO - investigate   let queue =  OperationQueue.main to work here.
     @objc static func mine(){
         
-        print("Current thread \(Thread.current)")
-        print("numberOfThreads:",ThreadSupervisor.numberOfThreads)
-     
+        if Miner.debug{
+            print("Current thread \(Thread.current)")
+            print("numberOfThreads:",ThreadSupervisor.numberOfThreads)
+        }
 
-        let miner = Miner(coinbase: "asdf", diff: 5000, threadCount: 4)
+        state.blockFound = false
+        
+        let miner = Miner(coinbase: "coinbaseAddressNotImplementedYet", diff: 20, threadCount: 4)
         let block = Block(prevHash: state.getPreviousBlock().blockHash, depth: state.blockChain.count, txns: [Transaction()], timestamp: Date().timeIntervalSince1970, difficulty: 5000, nonce: 0, hash: Data())
         
         block.nonce = 0
@@ -56,11 +67,14 @@ class Miner {
       
         // Here we're using the state.miningQueue so that we can sync up with the
         let queue =  state.miningQueue
+
         queue.isSuspended = true
-        queue.maxConcurrentOperationCount = miner.threadCount
+        queue.maxConcurrentOperationCount = Miner.threadCount
         
-        print("BEGIN - queue:",queue.operationCount)
-        for psuedoThreadId in 0...miner.threadCount-1{
+        if Miner.debug{
+            print("BEGIN - queue:",queue.operationCount)
+        }
+        for psuedoThreadId in 0...Miner.threadCount-1{
             
             let op = HashingOperation()
             
@@ -68,74 +82,92 @@ class Miner {
                 let candidate = block.newCopy()
                 
                 //Start each thread with a nonce at different spot
-                candidate.nonce =  UInt64(psuedoThreadId) * (UINT64_MAX/UInt64(miner.threadCount))
-      
-                func mineCandidateHash () {
+                candidate.nonce =  UInt64(psuedoThreadId) * (UINT64_MAX/UInt64(Miner.threadCount))
+                candidate.depthTarget = state.blockChain.count
+                
+                while !candidate.blockHash.binaryString.hasPrefix(Miner.hashDifficulty) {
                     candidate.nonce += 1
                     candidate.timestamp = Date().timeIntervalSince1970
                     candidate.blockHash = candidate.encoded().sha256
-                    if op.isCancelled {
+                    if candidate.depthTarget != state.blockChain.count{
+                        if Miner.debug {
+//                           print("depth target changed")
+                        }
                         return
                     }
-                    // We got one.
-                    if candidate.blockHash.binaryString.hasPrefix("00"){
+
+                    if op.isCancelled{
+                        if Miner.debug {
+//                          print("cancelled")
+                        }
                         return
                     }
-                    mineCandidateHash()
+                    if state.blockFound{
+                         return
+                    }
+                    
                 }
-
-                mineCandidateHash()
-
-                if op.isCancelled {
-                    return
-                }else{
+                
+                
+                if !state.blockFound {
                     queue.isSuspended = true
                     queue.cancelAllOperations()
-                     ThreadSupervisor.createAndRunThread(target: Miner.self, selector: #selector(Miner.blockFound), object: candidate)
-
+                    self.blockFound(candidate)
                 }
             }
             queue.addOperation(op)
         }
         
-        print("END - queue:",queue.operationCount)
+        if Miner.debug{
+            print("END - queue:",queue.operationCount)
+        }
+        
         queue.isSuspended = false
     }
     
+    // Thread Sanity Check - only add candidate block if another thread hasn't beat it to it
+    // ie. this blockFound method can be called simulatenously across execution of threads
+    
     @objc static func blockFound(_ block: Block) {
-        //Get user-readable date
 
-        // Thread Sanity Check - only add candidate block if another thread hasn't beat it to it
-        // ie. this blockFound method can be called simulatenously in runloop
-        if state.blockChain.last?.blockHash.binaryString == block.prevHash.binaryString{
-            let date = Date(timeIntervalSince1970: block.timestamp)
-            let formatter = DateFormatter()
-            formatter.dateFormat = "dd-MM-YYYY hh:mm:ss"
-            //        let dateString = formatter.string(from: date)
+        let lastBlockHash = state.blockChain.last?.blockHash.binaryString
+        // is this thread lagging - did the blockchain advance on another thread?
+        if  lastBlockHash == block.prevHash.binaryString{
             
-            //        print("prevHash  : \(block.prevHash.hexString)")
-            //        print("hash      : \(block.blockHash.hexString)")
-            //        print("nonce     : \(block.nonce)")
-            
-            //        print("merkleRoot: \(block.merkleRoot.hexString)")
-            //        print("timestamp : \(block.timestamp) (\(dateString))")
-            //        print("targetDiff: \(block.target)\n")
-            print("depth     : \(state.blockChain.count)")
-            state.blocksSinceDifficultyUpdate += 1
-            state.blockChain.append(block)
-            self.drainMiningQueueAndStartAgain()
+            if block.depthTarget == state.blockChain.count{
+                if !state.blockFound{
+                    state.blockFound = true
+//                    block.debug()
+                    print("depth     : \(state.blockChain.count)") // TODO - logInfo - this should increase and not skip!!!
+                    state.blocksSinceDifficultyUpdate += 1
+                    state.blockChain.append(block)
+                    Miner.drainMiningQueueAndStartAgain()
+//                     ThreadSupervisor.createAndRunThread(target: Miner.self, selector: #selector(drainMiningQueueAndStartAgain), object: nil)
+                }else{
+              //       print("blockFound on other thread")
+                }
+            }
         }else{
-                print("dropping.... ")
+            if Miner.debug{
+//                print("dropping.... ")
+            }
         }
         
 
     }
     
+    // N.B. if the miner stops and there's no working thread - need to tweak the timing
+    // known issue - if the hashDifficulty is too big - this can stalled if we don't wait long enough for all operations to cancel.
     @objc static func drainMiningQueueAndStartAgain(){
-        
+        let difficultyHeight = useconds_t(Miner.hashDifficulty.count * threadCount*state.miningQueue.operationCount)
         state.miningQueue.cancelAllOperations()
-        usleep(20000) // we need to give the mineCandidateHash some cycles to correctly cancel existing operations across threads - otherwise this thread can get caught up with cancelling - and basically miner runs out of things todo.
-        print(">>> queue:",state.miningQueue.operationCount)
-        ThreadSupervisor.createAndRunThread(target: self, selector: #selector(mine), object: nil)
+//        let sleepCount:useconds_t = difficulty < 2000 ? 200000:difficulty*2000
+        usleep(100000000 * difficultyHeight) // we need to give the some cycles to correctly cancel existing operations across threads - otherwise this thread can get caught up with cancelling - and basically miner runs out of things todo
+//        ThreadSupervisor.createAndRunThread(target: Miner.self, selector: #selector(mine), object: nil)
+        print("numberOfThreads:",ThreadSupervisor.numberOfThreads)
+        print("state.blockFound:",state.blockFound)
+        
+        Miner.mine()
+
     }
 }

--- a/Sources/App/Models/Miner.swift
+++ b/Sources/App/Models/Miner.swift
@@ -14,7 +14,7 @@ import Foundation
 // hashDifficulty low + high
 class Miner {
     
-    static var debug = true
+    static var debug = false
     
     //Address
     var coinbase: String
@@ -91,14 +91,14 @@ class Miner {
                     candidate.blockHash = candidate.encoded().sha256
                     if candidate.depthTarget != state.blockChain.count{
                         if Miner.debug {
-//                           print("depth target changed")
+                           print("depth target changed")
                         }
                         return
                     }
 
                     if op.isCancelled{
                         if Miner.debug {
-//                          print("cancelled")
+                          print("cancelled")
                         }
                         return
                     }
@@ -164,8 +164,8 @@ class Miner {
 //        let sleepCount:useconds_t = difficulty < 2000 ? 200000:difficulty*2000
         usleep(100000000 * difficultyHeight) // we need to give the some cycles to correctly cancel existing operations across threads - otherwise this thread can get caught up with cancelling - and basically miner runs out of things todo
 //        ThreadSupervisor.createAndRunThread(target: Miner.self, selector: #selector(mine), object: nil)
-        print("numberOfThreads:",ThreadSupervisor.numberOfThreads)
-        print("state.blockFound:",state.blockFound)
+//        print("numberOfThreads:",ThreadSupervisor.numberOfThreads)
+//        print("state.blockFound:",state.blockFound)
         
         Miner.mine()
 

--- a/Sources/App/Models/Miner.swift
+++ b/Sources/App/Models/Miner.swift
@@ -68,9 +68,8 @@ class Miner {
         block.blockHash = block.encoded().sha256
         
       
-        // Here we're using the state.miningQueue so that we can sync up with the
+        // Here we're using the state.hashingQueue so that we cancel uniformly across threads if a single thread finds a block.
         let hashQueue =  state.hashingQueue
-
         hashQueue.isSuspended = true
         hashQueue.maxConcurrentOperationCount = Miner.threadCount
         

--- a/Sources/App/Models/Miner.swift
+++ b/Sources/App/Models/Miner.swift
@@ -3,7 +3,7 @@
 //  App
 //
 //  Created by Valtteri Koskivuori on 04/01/2018.
-//
+// 
 
 import Foundation
 

--- a/Sources/App/Models/State.swift
+++ b/Sources/App/Models/State.swift
@@ -44,6 +44,21 @@ class State: Hashable {
     var currentDifficulty: Int64
     var blocksSinceDifficultyUpdate: Int
     
+    
+    private var _blockFound = false
+    var blockFound:Bool{
+        get {
+            return blockChain.queue.sync {
+                _blockFound
+            }
+        }
+        set {
+            blockChain.queue.sync {
+                _blockFound = newValue
+            }
+        }
+    }
+    
     private var _miningQueue = OperationQueue()
     var miningQueue:OperationQueue{
         get {
@@ -60,23 +75,7 @@ class State: Hashable {
     }
     
     
-    
 
-    private var _blockFound:Bool = false
-    var blockFound:Bool{
-        get {
-            return blockChain.queue.sync {
-                _blockFound
-            }
-        }
-        set {
-            blockChain.queue.sync {
-                _blockFound = newValue
-            }
-            
-        }
-    }
-    
     
     init() {
         print("Initializing client state")

--- a/Sources/App/Models/State.swift
+++ b/Sources/App/Models/State.swift
@@ -44,16 +44,34 @@ class State: Hashable {
     var currentDifficulty: Int64
     var blocksSinceDifficultyUpdate: Int
     
-    private var _blockDepth:Int = 0
-    var blockDepth:Int{
+    private var _miningQueue = OperationQueue()
+    var miningQueue:OperationQueue{
         get {
             return blockChain.queue.sync {
-                _blockDepth
+                _miningQueue
             }
         }
         set {
             blockChain.queue.sync {
-                _blockDepth = newValue
+                _miningQueue = newValue
+            }
+            
+        }
+    }
+    
+    
+    
+
+    private var _blockFound:Bool = false
+    var blockFound:Bool{
+        get {
+            return blockChain.queue.sync {
+                _blockFound
+            }
+        }
+        set {
+            blockChain.queue.sync {
+                _blockFound = newValue
             }
             
         }
@@ -79,7 +97,7 @@ class State: Hashable {
         //Blockchain state params
         self.currentDifficulty = 1
         self.blocksSinceDifficultyUpdate = 1
-        self.blockDepth = 1
+
         
         //self.initConnections()
         
@@ -107,9 +125,12 @@ class State: Hashable {
          }*/
     }
     
+    func cancelAllMiningOperations(){
+        miningQueue.cancelAllOperations()
+    }
     func startSync() {
         //Query other nodes for blockchain status, and then sync until latest block
-        print("Starting background sync, from block \(state.blockDepth)")
+        print("Starting background sync, from block \(state.blockChain.count)")
         self.p2pProtocol.sendRequest(request: .getBlock, to: nil, 0)
     }
     
@@ -171,14 +192,15 @@ class State: Hashable {
     }
     
     func getPreviousBlock() -> Block {
-        if self.blockChain.count > self.blockDepth - 1{
-            return self.blockChain[self.blockDepth - 1]
-        }else{
-            print("WARNING - self.blockDepth -1 < self.blockChain.count ")
-            print("self.blockChain.count:",self.blockChain.count)
-            //            print("self.blockDepth:",self.blockDepth)
-            return Block()
-        }
+        return self.blockChain.last!
+//        if self.blockChain.count > self.blockChain.count - 1{
+//
+//        }else{
+//            print("WARNING - self.blockDepth -1 < self.blockChain.count ")
+//            print("self.blockChain.count:",self.blockChain.count)
+//           print("self.blockDepth:",self.blockDepth)
+//            return Block()
+//        }
         
     }
     

--- a/Sources/App/Models/State.swift
+++ b/Sources/App/Models/State.swift
@@ -59,6 +59,21 @@ class State: Hashable {
         }
     }
     
+    private var _threadedHashingQueue = OperationQueue()
+    var hashingQueue:OperationQueue{
+        get {
+            return blockChain.queue.sync {
+                _threadedHashingQueue
+            }
+        }
+        set {
+            blockChain.queue.sync {
+                _threadedHashingQueue = newValue
+            }
+            
+        }
+    }
+    
     private var _miningQueue = OperationQueue()
     var miningQueue:OperationQueue{
         get {
@@ -73,7 +88,6 @@ class State: Hashable {
             
         }
     }
-    
     
 
     
@@ -97,6 +111,7 @@ class State: Hashable {
         self.currentDifficulty = 1
         self.blocksSinceDifficultyUpdate = 1
 
+        self.miningQueue.maxConcurrentOperationCount = 1
         
         //self.initConnections()
         

--- a/Sources/App/Models/ThreadSupervisor.swift
+++ b/Sources/App/Models/ThreadSupervisor.swift
@@ -1,0 +1,75 @@
+//
+//  ThreadSupervisor.swift
+//  FrontierCore
+//
+//  Created by Brent Simmons on 4/23/17.
+//  Copyright © 2017 Ranchero Software. All rights reserved.
+//
+
+import Foundation
+
+// When Frontier creates a thread, it should use ThreadSupervisor, which counts and manages threads. The thread verbs need ThreadSupervisor.
+
+class ManagedThread: Thread {
+    
+    var identifier = 0
+    
+    public override func main() {
+        
+        super.main()
+        ThreadSupervisor.threadDidComplete(identifier: identifier)
+    }
+}
+
+public typealias VoidBlock = () -> Void
+
+public struct ThreadSupervisor {
+    
+    public static let mainThreadID = 0
+    public static let unknownThreadID = -1
+    
+    public static var numberOfThreads: Int {
+        get {
+            return threads.count + 1 // Add one for main thread
+        }
+    }
+    
+    private static var threads = [Int: ManagedThread]()
+    private static let lock = NSLock()
+    private static var incrementingThreadID = 1
+    
+    public static func createAndRunThread(target: Any, selector: Selector, object argument: Any?) {
+        
+        let thread = ManagedThread(target: target, selector: selector, object: argument)
+        thread.name = "VaporCoin Supervisor Thread"
+        
+        lock.lock()
+        thread.identifier = incrementingThreadID
+        incrementingThreadID = incrementingThreadID + 1
+        threads[thread.identifier] = thread
+        lock.unlock()
+        
+        thread.start()
+    }
+    
+    public static func currentThreadID() -> Int {
+        
+        if Thread.isMainThread {
+            return mainThreadID
+        }
+        
+        if let thread = Thread.current as? ManagedThread {
+            return thread.identifier
+        }
+        return unknownThreadID
+    }
+    
+    // MARK: Thread callback
+    
+    static func threadDidComplete(identifier: Int) {
+        
+        lock.lock()
+        threads[identifier] = nil
+        lock.unlock()
+    }
+}

--- a/Sources/Run/main.swift
+++ b/Sources/Run/main.swift
@@ -16,6 +16,13 @@ import App
 ///
 /// .run() runs the Droplet's commands, 
 /// if no command is given, it will default to "serve"
+
+//For now init state by reading value from there.
+//print("BlockChain count: \(state.blockChain.count)")
+
+
+
+
 let config = try Config()
 try config.setup()
 


### PR DESCRIPTION
needs some proper unit tests.
with the added queues x3 - we can reliably interject / cancel when other signals (block found remote / propagation) occur from block chain.

so the mining queue is basically the recursion to find next block.
the hashing queue is parallel threaded to determine hash
the block found queue I added as a sanity check to prevent two blocks being found at same time.
There's also a block found state variable to help orchestrate things. 

you will notice that / they hang off the blockchain queue
the SynchronizedArray should prevent the underlying mutation of the blockchain data while all the threads are in action.

I've been testing and it seems stable. 

eg.

   ```swift
 var blockFound:Bool{
        get {
            return blockChain.queue.sync {
                _blockFound
            }
        }
        set {
            blockChain.queue.sync {
                _blockFound = newValue
            }
        }
    }


```

There's some delays that are added as bandaids which basically give the process some cycles on other threads to catch up.


eg
before we call mine - we sleep for a few milliseconds.
This delay variable value is more of an art that a science.

                    usleep(Miner.bandAidDelay)
                     Miner.mine()